### PR TITLE
This fixes an issue I encountered when I tried to create a new content t...

### DIFF
--- a/modules/node/content_types.inc
+++ b/modules/node/content_types.inc
@@ -260,13 +260,25 @@ function node_type_form_validate($form, &$form_state) {
 
   // Work out what the type was before the user submitted this form
   $old_type = $form_state['values']['old_type'];
+  $orig_type = trim($form_state['values']['orig_type']);
 
   $types = node_type_get_names();
 
   if (!$form_state['values']['locked']) {
+    // No content type should have a type value equal to the orig_type value
+    // of another content type.
+    $invalid_type = FALSE;
+    if ($type->type != $orig_type) {
+      $infos = node_type_get_types();
+      foreach ($infos as $info) {
+        if ($type->type == $info->orig_type) {
+	  $invalid_type = TRUE;
+	}
+      }
+    }
     // 'theme' conflicts with theme_node_form().
     // '0' is invalid, since elsewhere we check it using empty().
-    if (in_array($type->type, array('0', 'theme'))) {
+    if (in_array($type->type, array('0', 'theme')) || $invalid_type) {
       form_set_error('type', t("Invalid machine-readable name. Enter a name other than %invalid.", array('%invalid' => $type->type)));
     }
   }


### PR DESCRIPTION
...ype called 'sponsorship' and to my surprise it was

not showing up in the UI, so after banging my head a couples of times on the keyboard I entered mysql console and noticed that
the node_type table actually had my newly created content type but the problem was that the 'sponsorship option' content type
had the same orig_type value as my newly created content type so drupal got confused. Anyways, this patch will prevent anyone
from entering a duplicate machine readable name on content types in which their orig_type is the same.

see https://drupal.org/node/515454 for info on this core bug
