### PR TITLE
nyccamp.module addition with node/add workaround

### DIFF
--- a/sites/all/modules/CUSTOM/nyccamp/nyccamp.info
+++ b/sites/all/modules/CUSTOM/nyccamp/nyccamp.info
@@ -1,0 +1,6 @@
+name = NYC Camp Hacks & Misc Code
+description = This is the module to add misc code and hacks to the site.
+version = 7.x-1.0
+core = 7.x
+
+files[] = nyccamp.module

--- a/sites/all/modules/CUSTOM/nyccamp/nyccamp.module
+++ b/sites/all/modules/CUSTOM/nyccamp/nyccamp.module
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Redirect both anonymous & authenticated users to /user/login
+ * Users in the 'site admin' roles will bypass this rule.
+ * This is a temporaly workaround for issue #36
+ */
+global $user;
+$path = current_path();
+
+if ($path == 'node/add' && ! in_array('site admin',$user->roles)) {
+  drupal_goto('<front>');
+}


### PR DESCRIPTION
This is a workaround for issue #36. Currently what we have is not ideal for the time being as what you get is 
![untitled](https://f.cloud.github.com/assets/1696920/2291817/17dfd3f8-a048-11e3-9efb-22317ebf277d.png)

And normally you would click on "Add new content" but this links to "/node" which is the same place the path alias for "node/add" points to thus creating a loop. 

I know @willy said that Earl Miles uses panels to protect node/add access but until then this simply piece of code can allow site administrators to access "node/add" without being redirected to "/node".
