### PR TITLE
Updating README.md to reflect the new GitHub-only workflow.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 Introduction
 ============
-Read more in the [NYC Camp GitHub Wiki](http://github.com/NYC-Camp/website/wiki)
 
 Team Communications
 -------------------
-Join us in #nyccamp on irc.freenode.net to chat about NYC Camp.
+Join us in #nyccamp on [IRC](ircs://chat.freenode.net) to chat about NYC Camp.
+
+Issues are tracked on GitHub at [http://github.com/NYC-Camp/website/issues](http://github.com/NYC-Camp/website/issues).
+
+More info can be found on GitHub at [http://github.com/NYC-Camp/website/wiki](http://github.com/NYC-Camp/website/wiki).
 
 Pantheon + Github Workflow
 --------------------------

--- a/README.md
+++ b/README.md
@@ -1,21 +1,27 @@
 Introduction
 ============
+Read more in the [NYC Camp GitHub Wiki](http://github.com/NYC-Camp/website/wiki)
 
 Team Communications
 -------------------
 Join us in #nyccamp on irc.freenode.net to chat about NYC Camp.
 
 Pantheon + Github Workflow
--------------------------------------
+--------------------------
+All code for the site comes from the GitHub Repository located at https://github.com/NYC-Camp/website. All work must be done from
+Forks of that GitHub repository.  Do not clone the Pantheon repo, or commit and push to the Pantheon repo.
+
+This code is continuously mirrored to Pantheon with http://hubdrop.io, managed by @jonpugh. Changes pushed to the GitHub
+Repo will be pushed to Pantheon at most 4 minutes later.
 
 Below we have a summary of the git workflow that the team is using for purposes of developing the NYC Camp site. This workflow should allow for a larger, more distributed team where people can contribute by biting off smaller portions of the work from the PM tool -- for 2014, this will be the Trello board/cards https://trello.com/nyccamp2014. We’re hoping to improve on the workflow from prior years, where people had to be rockstars and tackle almost the entire site (e.g., Mark/Father Shawn in 2011, and Tim in 2013).
 
-Below we’ve added a ‘Brief Overview’ that outlines the 6 steps in our Git workflow. 
+Below we’ve added a ‘Brief Overview’ that outlines the 6 steps in our Git workflow.
 
-Our workflow varies slightly from the typical Pantheon workflow, in that we are using GitHub in order to make the workflow more transparent and allow for more detailed commenting/code review on GitHub (see steps 4 & 5). If you are new to Pantheon or want more details about the ‘under the hood process or Git commands, then you can see Section 3 of this document (which is a work in progress). 
- 
+Our workflow varies slightly from the typical Pantheon workflow, in that we are using GitHub in order to make the workflow more transparent and allow for more detailed commenting/code review on GitHub (see steps 4 & 5). If you are new to Pantheon or want more details about the ‘under the hood process or Git commands, then you can see Section 3 of this document (which is a work in progress).
+
 Brief Overview (6 steps)
--------------------------------
+------------------------
 
 ### Step 1 - Local Dev Setup:
 Setup your local dev environment. Ideally using the Vagrant-based approach set forth in Section 2 Below, or if preferable using the standard approach you’re comfortable with if you’re a more experienced developer.
@@ -23,52 +29,40 @@ Setup your local dev environment. Ideally using the Vagrant-based approach set f
 ### Step 2 - Pantheon Access:
 Get Pantheon access  (i.e., added to project, and getting the connection settings)
 
+This is optional, now that the code is being mirrored from GitHub. You only need Pantheon access if you need to access
+their dashboard.
 
-### Step 3 - Pantheon Branch (Local & MultiDev):
-Locally create a branch off ‘Integration’ on pantheon, and name it with your initial and a descriptive branch name: ‘yourinitials-feature-branch-name’; and then proceed using one of the two methods below depending on the scope of the work that you’re doing:
-   1. Local Branch: For all smaller scopes of work, you can simply used your local branch to do your development and then create a PR for code review as outlined below
-   2. Multidev: For broader scopes of work that are focused on major functionality or debugging, you case use the Pantheon UI to create a multidev environment on Pantheon which you and others can use to collaborate on test your work on Pantheon (note that you need to create the branch before you can spin up a multidev (see: https://www.youtube.com/watch?v=BI5azevzBZs).
+### Step 3 - Fork the Repo:
 
+Visit https://github.com/NYC-Camp/website and click "Fork" to create your own copy of the source code.
+
+If your change is minor you may work in the `master` branch of your fork.  If your change is major, you should make a new
+branch within your fork.
 
 ### Step 4 - GitHub Pull Request(PR)/Code Review:
-Once you’ve completed work on your new branch and are ready to contribute it back, a add Pull Request on GitHub in order to have another team member review your code
-* Make PR against integration
-* Tag others in your PR on Github for code review and/or email team@nyccamp.org
 
+Once you’ve completed work on your fork and are ready to contribute it back, a add Pull Request on GitHub in order to
+have another team member review your code.
+
+To create a pull request, visit your fork's page and click "Pull Request" at the top right of the files table.
+
+Tag others in your PR on Github for code review and/or email team@nyccamp.org
 
 ### Step 5 - Github Merge Pull Request:
-* Have someone other than yourself review your PR/code, and once approved they should merge your PR into the integration branch on GitHub.
-Step 5 - Push ‘integration’ from GitHub to Pantheon: 
-* Once your PR has been reviewed and merged into integration on GitHub, it needs to be pushed from GitHub to ‘integration on Pantheon for final testing/review on the integration branch/MultiDev on Pantheon. One of the maintainers/gatekeepers of the Pantheon integration branch will complete this -- likely Tony, Eric, Robbie, Mai,  Forest or Willy (other can get more involved in helping with that if needed).
 
-### Step 6 - Push ‘integration on Pantheon to Dev/Test/Live (Delete Branch)
-Once things have been then in turn merge those changes into ‘master on pantheon and through to dev, test and live so that they appear on the site. Once that’s complete, the new branch (and any MultiDev) should then be deleted if it’s no longer need any more.
+Have someone other than yourself review your PR/code, and once approved, they will merge your PR into the main NYC-Camp/website repo.
 
-Branching Tips/Commands
---------------------------------
+Once merged, the branch may be deleted
 
-Fetch the upstream branches
+### Step 6 - Deploy to Test, then Live
 
-    $ git fetch upstream
+After the merge the code will make it's way to the Pantheon dev site automatically. A QA team member will review all of
+the new changes on Dev, and once approved, will deploy the changes to Test to ensure it works with the latest Live database.
 
-Make a new branch on your local that tracks the upstream branch. For example, if you are working on the ‘alpha’ feature, you would:
+Once test is reviewed and all is well, the QA team member will deploy those commits to live.
 
-	$ git checkout -b alpha upstream/alpha
-
-which checks you into the alpha branch, or
-
-	$ git branch --track alpha upstream/alpha 
-
-which makes the alpha branch but leaves you in your existing branch
-
-
-Either way, do your work on the alpha feature in the alpha branch.
-
-	$ git checkout alpha
-
-Once you've finished the work on the alpha branch, commit your work to your local repository and push it to your origin.
-
-	$ git push origin alpha
+Pull Requests & Peer Review
+---------------------------
 
 Github has recently added a green colored “Compare & pull request” button on your repository's web page, which makes things simpler.
 
@@ -76,26 +70,11 @@ Go to: `https://github.com/YOURUSERNAME/website`
 
 You should see and your should click the “Compare & pull request”button
 
-Notice on the next screen that the pull request is automatically set up between NYC-Camp:alpha ... YOURUSERNAME:alpha
+Notice on the next screen that the pull request is automatically set up between NYC-Camp:master ... YOURUSERNAME:master
 
 Click the Send pull request button
 
 If on the next screen, you see: `This pull request can be automatically merged.` and a “Merge pull request” button, **DO NOT** click that button. That would defeat the whole purpose of peer review. A gatekeeper will merge your pull request after it has been reviewed.
 
-Assuming your work on the alpha branch is both code perfect and user experience perfect, you are done with the alpha branch and can, your time permitting, go on to a new feature and a new feature branch.
-
-#### Read more in the [NYC Camp GitHub Wiki] (This is still a @TODO item)
-
-[NYC Camp GitHub Wiki]:https://github.com/jmarkel/nyccamp2014/wiki
-
-
-Set of tools to make COD7 more useful for conference planning.
-
-In particular, the additions are aimed at making versions alpha2 and higher easier to use. COD 7alpha2 is the line that integrates OG, which brings with it both more powerful functionality, at the cost of some development pain. This module aims to bridge that gap.
-
-Originally developed for NYC Camp website (http://nyccamp.org) with the intent of releasing back to COD community.
-
-NB: Since NYC Camp is a 100% free event, initial Codify tools do not address paid registration issues. 
-
-@TODO- Featurize session grid views. 
+Assuming your work on your fork is both code perfect and user experience perfect, you are done with the fork and can, your time permitting, go on to a new feature and a new feature branch.
 


### PR DESCRIPTION
I removed a lot of stuff about "local branches" and Pantheon multidev. Most uses should just fork their own repo and use master branch.

Also removed some things that didn't seem relevant.
