### PR TITLE
workaround to the annoying node/add access bug introduced by og_field_pe...

### DIFF
--- a/sites/all/modules/CUSTOM/nyccamp_hacks/nyccamp_hacks.info
+++ b/sites/all/modules/CUSTOM/nyccamp_hacks/nyccamp_hacks.info
@@ -1,0 +1,6 @@
+name = NYC Camp Hacks
+description = This module shouldn't be here lulz
+version = 7.x-1.x-dev
+core = 7.x
+
+files[] = nyccamp_hacks.module

--- a/sites/all/modules/CUSTOM/nyccamp_hacks/nyccamp_hacks.module
+++ b/sites/all/modules/CUSTOM/nyccamp_hacks/nyccamp_hacks.module
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Implements hook_menu_alter()
+.*/
+function nyccamp_hacks_menu_alter(&$items){
+   $items['node/add']['access callback'] = 'nyccamp_hacks_node_add_access';
+}
+
+/**
+ * Custom access callback for node/add
+ * Only allow users with "administer nodes" permission to view node/add page.
+.*/
+function nyccamp_hacks_node_add_access(){
+  return user_access('administer nodes');
+}


### PR DESCRIPTION
Ok gang! This node/add issue is really getting to me and as a TEAM we have wasted enough f**\* time on this. This PR has a working _workaround_ to the issue which will prevent any users without the 'administer nodes' permissions from accessing node/add.

Somebody merge this damn pr or I will lulz. kthx

Oh and please don't forget to remove node/add path alias at `admin/config/search/path/delete/2956?destination=admin/config/search/path/list/node/add` and of course enable the module `drush -y en nyccamp_hacks @pantheon.nyccamp2014.live && drush cc all @pantheon.nyccamp2014.live`.

Enjoy the rest of your weekend. See you during the week, I should be resting but you keep pulling me in. 
Credits go to @jonpugh for the drupal centric code.
