### PR TITLE
Remove default email in cod_support module for registration

### DIFF
--- a/profiles/cod/modules/contrib/cod_support/cod_events/cod_events.features.field_instance.inc
+++ b/profiles/cod/modules/contrib/cod_support/cod_events/cod_events.features.field_instance.inc
@@ -515,7 +515,7 @@ function cod_events_field_default_field_instances() {
           'open' => '',
         ),
         'settings' => array(
-          'from_address' => 'example@example.com',
+          'from_address' => variable_get('site_mail', ini_get('sendmail_from')),
           'multiple_registrations' => 0,
         ),
         'status' => 1,


### PR DESCRIPTION
This patch replaces the hardcoded email used in the field_registration
instance used with cod_support and instead it will use the site's
default email and or ini sendmail_from from PHP.

This is in response to #181
