### PR TITLE
makes the Register for NYC Camp 14 block dynamic

### DIFF
--- a/sites/all/modules/CUSTOM/nyccamp/nyccamp.info
+++ b/sites/all/modules/CUSTOM/nyccamp/nyccamp.info
@@ -1,3 +1,4 @@
 name = NYC Camp
-description = Miscellaneous code for the nyccamp.org website
+description = A registration block and a field formatter for the Registration view.
+package = COD Extras
 core = 7.x

--- a/sites/all/modules/CUSTOM/nyccamp/nyccamp.module
+++ b/sites/all/modules/CUSTOM/nyccamp/nyccamp.module
@@ -45,3 +45,150 @@ function _nyccamp_ss_block_content() {
 
   return $block;
 }
+
+/**
+ * Implements hook_field_formatter_info().
+ */
+function nyccamp_field_formatter_info() {
+  return array(
+    'nyccamp_registration_form' => array(
+      'label' => t('Custom (NYCCamp)'),
+      'field types' => array('registration'),
+    ),
+  );
+}
+
+/**
+ * Implements hook_field_formatter_view().
+ */
+function nyccamp_field_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display) {
+  $element = array();
+  $promo_verbiage = 'NYC Camp 14 is a 100% free event. Thanks to the generous support of the United Nations, ' .
+    'this year\'s NYC Camp will be taking place at the UN Global Headquarters from April 10th through the 13th.' .
+    '<br><br>' .
+    'All new and returning website users should register for NYC Camp 14 using the form below.' .
+    '<br><br>' .
+    'Registering below signs you up to attend the sessions/keynotes day on Saturday and code sprints on Sunday ' .
+    'for which we have plenty of space/capacity.' .
+    '<br><br>' .
+    'Note that in the second week of March we will be opening registration for the specific training events ' .
+    'occurring Thursday April 10 and for the summit events happening Friday April 11. At that time, you will be able ' .
+    'to sign up to attend these events which will have limited capacity. Registration must be confirmed to attend these events.';
+  // TODO Make this text dynamic
+
+  // we know we should only have a single item
+  if (isset($items[0]['registration_type']) && !empty($items[0]['registration_type'])) {
+    $reg_type = registration_type_load($items[0]['registration_type']);
+    $settings = $display['settings'];
+    $label = !empty($settings['label']) ? $settings['label'] : $reg_type->label;
+    if ($display['type'] == 'nyccamp_registration_form') {
+      $account = $GLOBALS['user'];
+      list($entity_id) = entity_extract_ids($entity_type, $entity);
+      // If the user is already registered, display a link to edit the registration
+      if ($registration_id = _nyccamp_registration_is_registered_id($entity_type, $entity_id, NULL, $account->uid)) {
+        $registration = entity_load_single('registration', $registration_id);
+        $registration_states = registration_get_states_options();
+        $element[0]['link'] = array(
+          '#markup' => t('Your registration to NYC Camp is @state!<br><br>If you cannot attend, ' .
+            'will you please let us know by <a href="@url">Cancelling your registration</a>. ' .
+            'You may also register others using the form directly below.' . "\n",
+            array('@state' => $registration_states[$registration->state], '@url' => url('registration/' . $registration_id . '/delete'))),
+          '#prefix' => '<p>',
+          '#suffix' => '</p>',
+        );
+      } else {
+        $element[0]['link'] = array(
+          '#markup' => t($promo_verbiage),
+          '#prefix' => '<p>',
+          '#suffix' => '</p>',
+        );
+
+      }
+      // If the user can access the registration, show the form only if the event is not full
+      if ($registration_access = registration_register_page_access($entity_type, $entity)) { // && registration_status($entity_type, $entity_id)
+        if (registration_status($entity_type, $entity_id)) {
+          $registration = entity_get_controller('registration')->create(array(
+            'entity_type' => $entity_type,
+            'entity_id' => $entity_id,
+            'type' => $reg_type->name,
+          ));
+          $element[0]['form'] = drupal_get_form('registration_form', $registration);
+        }
+        else {
+          $element[0]['form'] = array(
+            '#markup' => t('Registrations are no longer available for %name.',
+              array('%name' => entity_label($entity_type, $entity))),
+            '#prefix' => '<p>',
+            '#suffix' => '</p>',
+          );
+        }
+      }
+      // Check whether the entity has any registration enabled
+      $settings = registration_entity_settings($entity_type, $entity_id);
+      $registration_enabled = $settings['status'];
+      // Otherwise (registration open, no existing registration, no access), display another message (login link)
+      if ($registration_enabled && !$registration_id && !$registration_access) {
+        $element[0] = array(
+          '#markup' => t('Registration is allowed for members only. Please <a href="@url">login</a> to register.',
+            array('@url' => url('user/login'))),
+        );
+      }
+    }
+  }
+  return $element;
+}
+/**
+ * Determine if a person has an active registration for a host entity.
+ * modified from registration_is_registered(Registration $registration, $anon_mail = NULL, $uid = NULL, $states = array())
+ *
+ * A person may be Drupal user account, identified by user uid ($uid).
+ * Or a non-user, identified by an email address ($anon_mail).
+ *
+ * One of $anon_mail or $uid is required.
+ *
+ * @param int $entity_type
+ *   Parent entity type
+ * @param int $entity_id
+ *   Parent entity id
+ * @param string $anon_mail
+ *   (optional) An email address.
+ * @param int $uid
+ *   (optional) A user account uid.
+ * @param array $states
+ *   (optional) An array of states to test against. Defaults to active states.
+ *
+ * @return int
+ *   Registration entity id
+ */
+function _nyccamp_registration_is_registered_id($entity_type, $entity_id, $anon_mail = NULL, $uid = NULL, $states = array()) {
+  // must provide an UID or anon_mail
+  // @todo: better course of action here?
+  if (!$anon_mail && !$uid) {
+    return FALSE;
+  }
+  if (empty($states)) {
+    $states = registration_get_active_states();
+  }
+  $query = db_select('registration', 'r')
+    ->fields('r', array('registration_id'))
+    ->condition('entity_id', $entity_id)
+    ->condition('entity_type', $entity_type)
+    ->condition('state', $states, 'IN');
+  if ($anon_mail) {
+    // There's a user with this email, check to make sure they're not registered.
+    if ($user = user_load_by_mail($anon_mail)) {
+      $query->condition(db_or()->condition('anon_mail', $anon_mail)
+        ->condition('user_uid', $user->uid));
+    }
+    else {
+      $query->condition('anon_mail', $anon_mail);
+    }
+  }
+  elseif ($uid) {
+    $query->condition('user_uid', $uid);
+  }
+  $results = $query->execute();
+  $ids = $results->fetchField();
+  $id = ($ids=='' ? 0 : $ids);
+  return $id;
+}


### PR DESCRIPTION
This code changes what's printed in the Register for NYC Camp 14 block on the user profile. You can see the code in action at:

http://qr-code3-nyccamp2014.gotpantheon.com/users/nyc-camp
