### PR TITLE
Set block title links in code

### DIFF
--- a/sites/all/modules/CUSTOM/nyccamp/nyccamp.module
+++ b/sites/all/modules/CUSTOM/nyccamp/nyccamp.module
@@ -64,3 +64,18 @@ function nyccamp_remove_messages() {
   // Retrieve all messages and clear the queue
   drupal_get_messages();
 }
+
+/**
+ * Implements hook_block_view_alter().
+ *
+ */
+function nyccamp_block_view_alter(&$data, $block) {
+  switch ($block->delta) {
+    case 'events_schedule_summits-block':
+      $data['subject'] = l(t('Summits (Fri Apr 11)'), '2014/summits');
+      break;
+    case 'events_schedule_trainings-block':
+      $data['subject'] = l(t('Trainings (Thu Apr 10)'), 'trainings');
+      break;
+  }
+}


### PR DESCRIPTION
This commit gets rid of the way block titles were set as links, instead
of adding a views header with the block title css, we just do this in code.

Whoever merges this will need to remove the views 'Global Text' in header on two of the views blocks that this pr alters.
- admin/structure/views/view/events_schedule_trainings/edit/block
- admin/structure/views/view/events_schedule_summits/edit/block

Also close #212 when merged. kthx :)
