### PR TITLE
#280 - Remove schedule icon from pages without first sidebar, fix styles for schedule view on mobile

### DIFF
--- a/sites/all/themes/zen_avenue/css/avenueresponsive.css
+++ b/sites/all/themes/zen_avenue/css/avenueresponsive.css
@@ -120,21 +120,12 @@
         height: auto;
 	}
 
-    .region-sidebar-first h2.block-title {
-        padding: 0;
-        font-size: 13px;
-    }
-
     .region-sidebar-first h3 {
         margin: 0 0 7px;
     }
 
 	.region-sidebar-first .block:hover {
 		background: none;
-	}
-	
-	.region-sidebar-first h2.block-title {
-		color: inherit;
 	}
 
 	#main .block {
@@ -231,7 +222,7 @@
 		overflow-x: scroll;
 	}
 
-	#block-block-11 p, .region-sidebar-first h2, .region-sidebar-first h2.block-title, .region-sidebar-first div.view-header h2 a {
+	#block-block-11 p, .region-sidebar-first div.view-header h2 a {
 		color: inherit;
 	}
 	

--- a/sites/all/themes/zen_avenue/templates/page--team.tpl.php
+++ b/sites/all/themes/zen_avenue/templates/page--team.tpl.php
@@ -104,7 +104,9 @@
     <?php endif; ?>
 
     <div id="min-menu"><a href="#">Menu</a></div>
-    <div id="min-schedule"><a href="#">Schedule</a></div>
+    <?php if ($is_front): ?>
+      <div id="min-schedule"><a href="#">Schedule</a></div>
+    <?php endif; ?>
     <?php print theme('links__system_main_menu', array(
       'links' => $main_menu,
       'attributes' => array(

--- a/sites/all/themes/zen_avenue/templates/page.tpl.php
+++ b/sites/all/themes/zen_avenue/templates/page.tpl.php
@@ -103,7 +103,9 @@
     <?php endif; ?>
 
     <div id="min-menu"><a href="#">Menu</a></div>
-    <div id="min-schedule"><a href="#">Schedule</a></div>
+    <?php if ($is_front): ?>
+      <div id="min-schedule"><a href="#">Schedule</a></div>
+    <?php endif; ?>
     <?php print theme('links__system_main_menu', array(
       'links' => $main_menu,
       'attributes' => array(
@@ -126,9 +128,9 @@
   <?php endif; ?>
 
   <?php if ($is_front): ?>
-    <?php if($page['sidebar_first']) { 
+    <?php if($page['sidebar_first']) {
 	 print render($page['sidebar_first']);
-      } 
+      }
     ?>
   <?php endif; ?>
 


### PR DESCRIPTION
@likewhoa please review.

This is a fix for issue https://github.com/NYC-Camp/website/issues/280

I decided just to remove schedule icon from pages that don't have first sidebar, because it will affect big part of theme functionality to bring first sidebar to all pages and I don't want to break anything in last moment before Camp.
